### PR TITLE
GHC-8.10.7, Cabal-3.4, re-enable sdl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,12 @@ jobs:
     strategy:
       matrix:
         sys:
-          # The `sdl2` package is currently not compiling for macOS.
-          # Reason: unknown.
-          # Try again with the next GHC release.
-          - { os: macOS-latest,   shell: bash,        flags: '-sdl2 glfw'}
+          - { os: macOS-latest,   shell: bash,        flags: 'sdl2 glfw'}
           - { os: ubuntu-latest,  shell: bash,        flags: 'sdl2 glfw'}
           - { os: windows-latest, shell: 'msys2 {0}', flags: 'sdl2 glfw'}
-        cabal: ["3.2"]
+        cabal: ["3.4"]
         ghc:
-          - "8.10.5"
+          - "8.10.7"
 
     defaults:
       run:

--- a/wgpu-hs/wgpu-hs.cabal
+++ b/wgpu-hs/wgpu-hs.cabal
@@ -29,7 +29,7 @@ flag sdl2
 
 common base
   default-language: Haskell2010
-  build-depends:    base ^>=4.14.0.0
+  build-depends:    base ^>=4.14.3.0
 
 common ghc-options
   ghc-options:

--- a/wgpu-raw-hs-codegen/wgpu-raw-hs-codegen.cabal
+++ b/wgpu-raw-hs-codegen/wgpu-raw-hs-codegen.cabal
@@ -12,7 +12,7 @@ extra-source-files: CHANGELOG.md
 
 common base
   default-language: Haskell2010
-  build-depends:    base ^>=4.14.0.0
+  build-depends:    base ^>=4.14.3.0
 
 common ghc-options
   ghc-options:

--- a/wgpu-raw-hs/wgpu-raw-hs.cabal
+++ b/wgpu-raw-hs/wgpu-raw-hs.cabal
@@ -27,7 +27,7 @@ flag sdl2
 
 common base
   default-language: Haskell2010
-  build-depends:    base ^>=4.14.0.0
+  build-depends:    base ^>=4.14.3.0
 
 common ghc-options
   ghc-options:


### PR DESCRIPTION
- Bump GHC to 8.10.7
- Bump Cabal to 3.4
- Re-enable sdl for macOS